### PR TITLE
Release 2/1/2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@apollo/experimental-nextjs-app-support": "^0.0.0-commit-7dad495",
+    "@apollo/experimental-nextjs-app-support": "^0.7.0",
     "@types/node": "20.4.4",
     "@types/react": "18.2.46",
     "@types/react-dom": "18.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,12 +30,13 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@apollo/experimental-nextjs-app-support@^0.0.0-commit-7dad495":
-  version "0.0.0-commit-7dad495"
-  resolved "https://registry.yarnpkg.com/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.0.0-commit-7dad495.tgz#926c5267fabde2b2fb9e3de4cf69c86128d7b500"
-  integrity sha512-YBUSFb7y/bZgbTLiOILD765xQ3gXPi2TpmzyUtGl4VXceYAP6oHSPUWB9qZF9rcV1eNcTIlKscKT1wJ5n3KvoQ==
+"@apollo/experimental-nextjs-app-support@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.7.0.tgz#3fa258d3a7870946d56992e6cbae0ef91137b270"
+  integrity sha512-BtQ/dSN81wKIaQ4pGT62fYyuEEnNSqZXpwv4QdMNd77nl3WcRbgbGPQPwhv8UliwyOhVHAZ9WwBj2Clj26hSrA==
   dependencies:
-    superjson "^1.12.2"
+    server-only "^0.0.1"
+    superjson "^1.12.2 || ^2.0.0"
     ts-invariant "^0.10.3"
 
 "@aws-crypto/crc32@3.0.0":
@@ -3676,6 +3677,11 @@ semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 set-function-length@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
@@ -3861,10 +3867,10 @@ sucrase@^3.32.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
-superjson@^1.12.2:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.1.tgz#a0b6ab5d22876f6207fcb9d08b0cb2acad8ee5cd"
-  integrity sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==
+"superjson@^1.12.2 || ^2.0.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-2.2.1.tgz#9377a7fa80fedb10c851c9dbffd942d4bcf79733"
+  integrity sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==
   dependencies:
     copy-anything "^3.0.2"
 


### PR DESCRIPTION
…5 to 0.7.0 (#17)

Bump @apollo/experimental-nextjs-app-support

Bumps [@apollo/experimental-nextjs-app-support](https://github.com/apollographql/apollo-client-nextjs) from 0.0.0-commit-7dad495 to 0.7.0.
- [Release notes](https://github.com/apollographql/apollo-client-nextjs/releases)
- [Commits](https://github.com/apollographql/apollo-client-nextjs/commits/v.0.7.0)

---
updated-dependencies:
- dependency-name: "@apollo/experimental-nextjs-app-support" dependency-type: direct:production ...